### PR TITLE
Macadmins python

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -13,7 +13,7 @@
 	<key>display_name</key>
 	<string>DISPLAY_NAME</string>
 	<key>installcheck_script</key>
-	<string>#!/usr/local/munki/munki-python
+	<string>#!/usr/local/bin/managed_python3
 import subprocess
 import sys
 import shlex
@@ -80,7 +80,7 @@ sys.exit(1)
 	<key>name</key>
 	<string>AddPrinter_DISPLAYNAME</string>
 	<key>preinstall_script</key>
-    <string>#!/usr/local/munki/munki-python
+    <string>#!/usr/local/bin/managed_python3
 import subprocess
 import sys
 
@@ -106,7 +106,7 @@ else:
     sys.exit(543)
 </string>
     <key>postinstall_script</key>
-	<string>#!/usr/local/munki/munki-python
+	<string>#!/usr/local/bin/managed_python3
 import subprocess
 import sys
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a fork of [nmcspadden/PrinterGenerator](https://github.com/nmcspadden/Pr
 This updated version implements some cool new things:
 
 * Support for macOS 10.14, 10.15, 11, 12, 13, 14, 15 and 26
-* Usage of [MacAdmins Python](https://github.com/macadmins/python) (munki-python was removed in Munki 7)
+* Usage of [MacAdmins Python](https://github.com/macadmins/python) (munki-python was removed in Munki 7), works with MacAdmins Python version 3.10 and 3.12
 * Enhances usage of Microsoft Excel to edit the CSV file: for regions which use the comma as the decimal separator, Microsoft Excel expects a semicolon as separator in CSV files. The script will distinguish between both variants.
 * The order of the csv columns do not have to be preserved, but **keep the names of the 1st row**.
 * Sanity checks for the csv fields

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is a fork of [nmcspadden/PrinterGenerator](https://github.com/nmcspadden/Pr
 
 This updated version implements some cool new things:
 
-* Support for macOS 10.14, 10.15, 11, 12, 13 and 14
-* Usage of the Munki-included Python3
+* Support for macOS 10.14, 10.15, 11, 12, 13, 14, 15 and 26
+* Usage of [MacAdmins Python](https://github.com/macadmins/python) (munki-python was removed in Munki 7)
 * Enhances usage of Microsoft Excel to edit the CSV file: for regions which use the comma as the decimal separator, Microsoft Excel expects a semicolon as separator in CSV files. The script will distinguish between both variants.
 * The order of the csv columns do not have to be preserved, but **keep the names of the 1st row**.
 * Sanity checks for the csv fields
@@ -19,7 +19,6 @@ This updated version implements some cool new things:
 * Option to define a path to Munki repo and an optional subdirectory
 * Option to define a separate name for the Munki pkginfo item
 * Option to define a Munki category
-* **This script should preserve backward compatibility!**
 
 ## Caveats
 

--- a/print_generator.py
+++ b/print_generator.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/munki-python
+#!/usr/local/bin/managed_python3
 from __future__ import absolute_import, print_function
 
 import argparse


### PR DESCRIPTION
Tested successfully on ARM w/ macOS 15.7.2. Maybe MacAdmin's Python should be added as requirement in `AddPrinter-Template.plist`? Or be better pointed out in the README.md?